### PR TITLE
feat(mdx): add MDX components for callouts and code blocks

### DIFF
--- a/src/app/[subject]/page.tsx
+++ b/src/app/[subject]/page.tsx
@@ -12,6 +12,7 @@ import { ArticleStructuredData } from '@/components/StructuredData';
 import { subjects } from '@/lib/subjects';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
+import mdxComponents from '@/components/mdx';
 
 export async function generateStaticParams() {
   return Object.keys(subjects).map((subject) => ({
@@ -37,24 +38,6 @@ export default async function SubjectPage({ params }: { params: Promise<{ subjec
   }
 
   const { content, isMDX } = getContentWithMeta(subject.markdownFile, subject.cheatsheetName);
-
-  // Minimal MDX components map (can be extracted later)
-  // const mdxComponents = {
-  //   a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-  //     <a {...props} className={"text-[#007AFF] hover:text-[#0056CC] underline underline-offset-2 " + (props.className || '')} />
-  //   ),
-  // };
-  const mdxComponents = {
-    a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-      <a
-        {...props}
-        className={
-          "text-white hover:text-gray-300 transition-colors " +
-          (props.className || "")
-        }
-      />
-    ),
-  };
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#0F0F1A] to-[#1A1A2E]">

--- a/src/components/mdx/Callout.tsx
+++ b/src/components/mdx/Callout.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+
+export type CalloutType = 'info' | 'warning' | 'success' | 'error';
+
+const tone = {
+  info: {
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="shrink-0">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+        <path d="M12 8h.01M11 12h2v6h-2z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    ),
+    classes: 'border-blue-400/30 bg-blue-400/10 text-blue-200',
+  },
+  warning: {
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="shrink-0">
+        <path d="M12 2l10 18H2L12 2z" stroke="currentColor" strokeWidth="2" />
+        <path d="M12 9v5M12 18h.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    ),
+    classes: 'border-yellow-400/30 bg-yellow-400/10 text-yellow-200',
+  },
+  success: {
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="shrink-0">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+        <path d="M8 12l3 3 5-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+    classes: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200',
+  },
+  error: {
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="shrink-0">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+        <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    ),
+    classes: 'border-red-400/30 bg-red-400/10 text-red-200',
+  },
+} as const;
+
+export default function Callout({ type = 'info', title, children }: { type?: CalloutType; title?: string; children: ReactNode }) {
+  const t = tone[type];
+  const role = type === 'error' || type === 'warning' ? 'alert' : 'note';
+
+  return (
+    <div role={role} className={`not-prose my-4 rounded-xl border px-4 py-3 flex gap-3 items-start ${t.classes}`}>
+      <span aria-hidden>{t.icon}</span>
+      <div className="min-w-0">
+        {title ? <div className="font-semibold mb-1">{title}</div> : null}
+        <div className="text-sm leading-relaxed">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mdx/CodeBlock.tsx
+++ b/src/components/mdx/CodeBlock.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+// This component is used as an override for the `pre` tag in MDX.
+// MDXRemote will pass something like <pre><code class="language-js">...</code></pre>
+// We enhance it with a language badge and a copy button.
+export default function CodeBlock(props: React.HTMLAttributes<HTMLPreElement>) {
+  const [copied, setCopied] = useState(false);
+
+  // Find the code element child and extract language + text
+  const { language, code } = useMemo(() => {
+    try {
+      // @ts-expect-error MDX child typing is permissive
+      const child = props.children?.props ? props.children : Array.isArray(props.children) ? props.children[0] : null;
+      const codeEl = child && child.props ? child : null;
+      const className: string = codeEl?.props?.className || '';
+      const langMatch = className.match(/language-([\w-]+)/);
+      const language = langMatch ? langMatch[1] : undefined;
+      const code = typeof codeEl?.props?.children === 'string' ? codeEl.props.children : Array.isArray(codeEl?.props?.children) ? codeEl.props.children.join('') : '';
+      return { language, code };
+    } catch {
+      return { language: undefined, code: '' };
+    }
+  }, [props.children]);
+
+  const onCopy = async () => {
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(code);
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = code;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.warn('Copy failed', err);
+    }
+  };
+
+  return (
+    <div className="relative group">
+      {/* Language badge */}
+      {language ? (
+        <div className="absolute top-2 left-2 text-[11px] uppercase tracking-wide bg-white/10 text-white border border-white/20 rounded px-2 py-0.5 select-none z-10">
+          {language}
+        </div>
+      ) : null}
+  
+      {/* Copy button */}
+      <button
+        type="button"
+        onClick={onCopy}
+        className="absolute top-2 right-2 text-xs rounded px-2 py-1 bg-white/10 hover:bg-white/20 border border-white/10 text-white/80 transition-opacity opacity-0 group-hover:opacity-100 z-10"
+        aria-label="Copy code"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+  
+      {/* Pre block with padding so content never overlaps */}
+      <pre
+        {...props}
+        className={`
+          ${props.className ?? ""}
+          mt-8    /* push code content down below badge + button */
+          rounded-lg
+          overflow-x-auto
+        `}
+        style={{ paddingTop: '2.5rem' }}  // 40px of top padding
+      />
+    </div>
+  );  
+}

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -1,0 +1,23 @@
+import Callout from './Callout';
+import CodeBlock from './CodeBlock';
+import type { MDXComponents } from 'mdx/types';
+
+// Central MDX components map to be passed to MDXRemote
+export const mdxComponents: MDXComponents = {
+  // Override standard tags
+  pre: (props) => <CodeBlock {...props} />,
+  a: (props) => {
+    const { className = '', ...rest } = props as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    return (
+      <a
+        {...rest}
+        className={("text-white hover:text-gray-300 transition-colors " + className).trim()}
+      />
+    );
+  },
+
+  // Custom shortcodes usable directly in MDX
+  Callout,
+};
+
+export default mdxComponents;

--- a/src/content/python.mdx
+++ b/src/content/python.mdx
@@ -1,5 +1,15 @@
 # Python Cheatsheet
 
+<Callout type="warning" title="Caution">
+  This action modifies files.
+</Callout>
+
+<Callout type="warning" title="Caution">
+  This action modifies files.
+</Callout>
+
+
+
 ## Variables & Data Types
 
 


### PR DESCRIPTION
Add Callout and CodeBlock components to enhance MDX content rendering. Callout supports multiple types (info, warning, success, error) with styled icons and text. CodeBlock adds language badges and copy functionality. Centralize MDX components in index.tsx for cleaner imports.