### PR TITLE
feat(code-highlighting): improve syntax highlighting with auto-detection

### DIFF
--- a/src/app/[subject]/page.tsx
+++ b/src/app/[subject]/page.tsx
@@ -74,7 +74,7 @@ export default async function SubjectPage({ params }: { params: Promise<{ subjec
               options={{
                 mdxOptions: {
                   remarkPlugins: [remarkGfm],
-                  rehypePlugins: [rehypeHighlight, rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]],
+                  rehypePlugins: [[rehypeHighlight, { detect: true }], rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]],
                 },
               }}
               components={mdxComponents}
@@ -82,7 +82,7 @@ export default async function SubjectPage({ params }: { params: Promise<{ subjec
           ) : (
             <ReactMarkdown 
               remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeHighlight, rehypeRaw]}
+              rehypePlugins={[[rehypeHighlight, { detect: true }], rehypeRaw]}
             >
               {content}
             </ReactMarkdown>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,7 +68,7 @@
   }
 
   .prose code {
-    @apply bg-blue-500/10 text-blue-500 px-2 py-1 rounded text-sm font-mono;
+    @apply font-mono px-1 py-0.5 rounded;
   }
 
   .prose pre {
@@ -76,7 +76,7 @@
   }
 
   .prose pre code {
-    @apply bg-transparent text-gray-300 p-0;
+    @apply bg-transparent p-0 font-mono;
   }
 
   .prose blockquote {
@@ -147,6 +147,3 @@
 .prose h6 a:hover {
   color: #007AFF; /* matches your back button */
 }
-
-
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import 'highlight.js/styles/github-dark-dimmed.css';
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { AuthProvider } from "@/contexts/AuthContext";


### PR DESCRIPTION
Add github-dark-dimmed theme for highlight.js and enable language auto-detection Simplify code styling in prose and update rehypeHighlight configuration